### PR TITLE
Fixed : Updating apt-get before installing axel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 sudo: required
+before_install:
+  - sudo apt-get install -y libxml2-dev
+addons:
+  apt:
+    update: true
 language: scala
 scala:
   - 2.10.4


### PR DESCRIPTION
Travis-ci does not run `sudo apt-get update` by default, so its not able to find axel.
By this PR it will update apt-get and  installs axel